### PR TITLE
Feature/games

### DIFF
--- a/cogs/fun.py
+++ b/cogs/fun.py
@@ -55,7 +55,7 @@ class Fun(commands.Cog, description="Fun commands."):
                     data = io.BytesIO(await response.read())
                     await ctx.send(file=discord.File(data, "oogway_quote.png"))
 
-    @commands.command(aliases=["dict"], brief="Gets the definition(s) of the specified word.", description="This command will ge the definition(s) of the word you specified.")
+    @commands.command(aliases=["dict"], brief="Gets the definition(s) of the specified word.", description="This command will get the definition(s) of the word you specified.")
     async def dictionary(self, ctx: commands.Context, *, word: str):
         dictionary = PyDictionary()
         definitions = dictionary.meaning(word)

--- a/cogs/games.py
+++ b/cogs/games.py
@@ -75,7 +75,7 @@ class Games(commands.Cog, description="Games commands."):
             try:
                 ans = await self.client.wait_for('message', check=checkAnswer, timeout = 60)
             except asyncio.TimeoutError:
-                await ctx.send(embed=timeOutEmbed)
+                await ctx.send(embed=timeOutEmbed, delete_after=60)
             if ans.content.lower() in ["y", "yes",]:
                 await ctx.send(embed=discord.Embed(title="Zen | Games", description =f"{ans.author.name} has accepted the challenge!"), delete_after=60)
             else:
@@ -96,7 +96,7 @@ class Games(commands.Cog, description="Games commands."):
             try:
                 p1Input = await self.client.wait_for("message", check=checkP1Move, timeout = 60)
             except asyncio.TimeoutError:
-                await ctx.send(embed=timeOutEmbed)
+                await ctx.send(embed=timeOutEmbed, delete_after=60)
                 return
             p1Move = playerMoves[p1Input.content.lower()]
 
@@ -108,7 +108,7 @@ class Games(commands.Cog, description="Games commands."):
                 try:
                     p2Input = await self.client.wait_for("message", check=checkP2Move, timeout = 60)
                 except asyncio.TimeoutError:
-                    await ctx.send(embed=timeOutEmbed)
+                    await ctx.send(embed=timeOutEmbed, delete_after=60)
                 p2Move = playerMoves[p2Input.content.lower()]
             
             winner = checkWinner(p1Move, p2Move)

--- a/cogs/games.py
+++ b/cogs/games.py
@@ -71,7 +71,7 @@ class Games(commands.Cog, description="Games commands."):
         else: 
             player2 = member.name
             await ctx.send(embed=discord.Embed(title= "Zen | Games", description = f"""{member.mention}, You have been challenged to a game of 
-            Rock-Paper-Scissors by {player1}! Do you accept? (y/n)"""))
+            Rock-Paper-Scissors by {player1}! Do you accept? (y/n)"""), delete_after=60)
             try:
                 ans = await self.client.wait_for('message', check=checkAnswer, timeout = 60)
             except asyncio.TimeoutError:
@@ -92,54 +92,53 @@ class Games(commands.Cog, description="Games commands."):
         round = 1
         finalWinner = None
 
-        while round < 6:
+        while p1Points < 2 or p2Points < 2:
             await ctx.author.send(embed=discord.Embed(title="Zen | Games", description=f"Round {round}: {chooseMove}"), delete_after=60)
             try:
                 p1Input = await self.client.wait_for("message", check=checkP1Move, timeout = 60)
+                p1Move = playerMoves[p1Input.content.lower()]
             except asyncio.TimeoutError:
                 await ctx.send(embed=timeOutEmbed, delete_after=60)
                 return
-            p1Move = playerMoves[p1Input.content.lower()]
 
             if player2 == "The Zen Bot":
                 p2Move = botMoves[random.randint(1, 3)]
-                print(p2Move)
             else:
                 await member.send(embed=discord.Embed(title="Zen | Games", description=f"Round {round}: {chooseMove}"), delete_after=60)
                 try:
                     p2Input = await self.client.wait_for("message", check=checkP2Move, timeout = 60)
+                    p2Move = playerMoves[p2Input.content.lower()]
                 except asyncio.TimeoutError:
                     await ctx.send(embed=timeOutEmbed, delete_after=60)
                     return
-                p2Move = playerMoves[p2Input.content.lower()]
             
             winner = checkWinner(p1Move, p2Move)
             if winner == player1:
                 p1Points += 1
-                roundResult = f"{player1} wins this round! {p1Move} Beats {p2Move}. Score: {p1Points} : {p2Points}"
+                roundResult = f"{player1} wins this round! {p1Move} Beats {p2Move}. Score: {p1Points} - {p2Points}"
             elif winner == player2:
                 p2Points += 1
-                roundResult = f"{player2} wins this round! {p2Move} Beats {p1Move}. Score: {p1Points} : {p2Points}"
+                roundResult = f"{player2} wins this round! {p2Move} Beats {p1Move}. Score: {p1Points} - {p2Points}"
             else:
-                roundResult = f"Tie! Both players chose {p1Move}. Score: {p1Points} : {p2Points}"
+                roundResult = f"Tie! Both players chose {p1Move}. Score: {p1Points} - {p2Points}"
 
-            await ctx.author.send(embed=discord.Embed(title="Zen | Games", description=f"{roundResult}"), delete_after=60)
+            roundEmbed = discord.Embed(title="Zen | Games", description=f"{roundResult}")
+            await ctx.author.send(embed=roundEmbed, delete_after=60)
+            if player2 != "The Zen Bot":
+                await member.send(embed=roundEmbed, delete_after=60)
             
-            if member != "The Zen Bot":
-                await member.send(embed=discord.Embed(embed=discord.Embed, title="Zen | Games", description=f"{roundResult}"), delete_after=60)
-            
-            if p1Points == 3:
+            if p1Points == 2:
                 finalWinner = player1
                 break
-            elif p2Points == 3:
+            elif p2Points == 2:
                 finalWinner = player2
                 break
             round += 1
         
         if p1Points != p2Points:
-            await ctx.send(embed=discord.Embed(title="Zen | Games", description=f"{finalWinner} wins the game! Final Score: {max(p1Points, p2Points)} Beats {min(p1Points, p2Points)}"), delete_after=60)
+            await ctx.send(embed=discord.Embed(title="Zen | Games", description=f"{finalWinner} wins the game! Final Score: {max(p1Points, p2Points)} - {min(p1Points, p2Points)}"), delete_after=60)
         else: 
-            await ctx.send(embed=discord.Embed(title="Zen | Games", description=f"Tie! Final Score: {p1Points, p2Points}"), delete_after=60)
+            await ctx.send(embed=discord.Embed(title="Zen | Games", description=f"Tie! Final Score: {p1Points} - {p2Points}"), delete_after=60)
 
 async def setup(client):
     await client.add_cog(Games(client))

--- a/cogs/games.py
+++ b/cogs/games.py
@@ -1,15 +1,143 @@
 import discord
 from discord.ext import commands
 from discord import app_commands
+import random
+import asyncio
  
 class Games(commands.Cog, description="Games commands."):
     
     def __init__(self, client: commands.Bot):
         self.client = client
-        
+
     @commands.Cog.listener()
     async def on_ready(self):
         print("Games module has been loaded.")
+    
+    @commands.command(aliases=["rps"], brief="Play Rock-Paper-Scissors, Best of 5", description="""This command will allow you to play a 
+    Rock-Paper-Scissors match, @ a user after the command to play against them or you will be matched against the infamous Zen Bot.""")
+    async def rockpaperscissors(self, ctx: commands.Context, member: discord.Member = None): 
+        timeOutEmbed = discord.Embed(title="Zen | Games", description="Too long! Game cancelled.")
+        botMoves  = {
+            1 : 'Rock',
+            2 : 'Paper',
+            3 : 'Scissors'
+        }
+        playerMoves = {
+            'r': 'Rock',
+            'rock': 'Rock',
+            'p' : 'Paper',
+            'paper' : 'Paper',
+            's' : 'Scissors',
+            'scissors' : 'Scissors'
+        }
+        def checkAnswer(answer):
+            if answer.content.lower() in ["y", "yes", "n", "no"] and answer.channel == ctx.channel:
+                return True
+
+        def checkP1Move(move):
+            if move.content.lower() in ["r", "rock", "p", "paper", "s", "scissors"] and move.channel == ctx.author.dm_channel:
+                return True
+
+        def checkP2Move(move):
+            if move.content.lower() in ["r", "rock", "p", "paper", "s", "scissors"] and move.channel == member.dm_channel:
+                return True
+
+        def checkWinner(p1Move, p2Move):
+            if p1Move == p2Move:
+                return None
+            if p1Move == 'Rock':
+                if p2Move == "Paper":
+                    return player2
+                else: 
+                    return player1
+            if p1Move == 'Paper':
+                if p2Move == "Scissors":
+                    return player2
+                else: 
+                    return player1
+            if p1Move == 'Scissors':
+                if p2Move == "Rock":
+                    return player2
+                else: 
+                    return player1
+
+        player1 = ctx.author.name
+        
+        if member is None:
+            player2 = "The Zen Bot" 
+        elif member == ctx.author:
+            await ctx.send(embed=discord.Embed(title="Zen | Games", description = f"{player1} will play against {player1}! ... Wait, no..."), delete_after=60)
+            return
+        else: 
+            player2 = member.name
+            await ctx.send(embed=discord.Embed(title= "Zen | Games", description = f"""{member.mention}, You have been challenged to a game of 
+            Rock-Paper-Scissors by {player1}! Do you accept? (y/n)"""))
+            try:
+                ans = await self.client.wait_for('message', check=checkAnswer, timeout = 60)
+            except asyncio.TimeoutError:
+                await ctx.send(embed=timeOutEmbed)
+            if ans.content.lower() in ["y", "yes",]:
+                await ctx.send(embed=discord.Embed(title="Zen | Games", description =f"{ans.author.name} has accepted the challenge!"), delete_after=60)
+            else:
+                await ctx.send(embed=discord.Embed(title="Zen | Games", description =f"{ans.author.name} has declined the challenge!"), delete_after=60)
+                return
+
+        await ctx.send(embed=discord.Embed(title="Zen | Games", description =f"""Starting a game of Rock-Paper-Scissors... 
+        {player1} will be matched against {player2}. Each player will be privately messaged to get their weapon of choice."""), delete_after=60)
+        
+        chooseMove = "Choose between: Rock('r'), Paper('p'), or Scissors('s')"
+        p1Points = 0
+        p2Points = 0
+        round = 1
+        finalWinner = None
+
+        while round < 6:
+            await ctx.author.send(embed=discord.Embed(title="Zen | Games", description=f"Round {round}: {chooseMove}"), delete_after=60)
+            try:
+                p1Input = await self.client.wait_for("message", check=checkP1Move, timeout = 60)
+            except asyncio.TimeoutError:
+                await ctx.send(embed=timeOutEmbed)
+                return
+            p1Move = playerMoves[p1Input.content.lower()]
+
+            if player2 == "The Zen Bot":
+                p2Move = botMoves[random.randint(1, 3)]
+                print(p2Move)
+            else:
+                await member.send(embed=discord.Embed(title="Zen | Games", description=f"Round {round}: {chooseMove}"), delete_after=60)
+                try:
+                    p2Input = await self.client.wait_for("message", check=checkP2Move, timeout = 60)
+                except asyncio.TimeoutError:
+                    await ctx.send(embed=timeOutEmbed)
+                p2Move = playerMoves[p2Input.content.lower()]
+            
+            winner = checkWinner(p1Move, p2Move)
+            if winner == player1:
+                p1Points += 1
+                roundResult = f"{player1} wins this round! {p1Move} Beats {p2Move}. Score: {p1Points} : {p2Points}"
+            elif winner == player2:
+                p2Points += 1
+                roundResult = f"{player2} wins this round! {p2Move} Beats {p1Move}. Score: {p1Points} : {p2Points}"
+            else:
+                roundResult = f"Tie! Both players chose {p1Move}. Score: {p1Points} : {p2Points}"
+
+            await ctx.author.send(embed=discord.Embed(title="Zen | Games", description=f"{roundResult}"), delete_after=60)
+            
+            if member != "The Zen Bot":
+                await member.send(embed=discord.Embed(embed=discord.Embed, title="Zen | Games", description=f"{roundResult}"), delete_after=60)
+            
+            if p1Points == 3:
+                finalWinner = player1
+                break
+            elif p2Points == 3:
+                finalWinner = player2
+                break
+            round += 1
+        
+        if p1Points != p2Points:
+            await ctx.send(embed=discord.Embed(title="Zen | Games", description=f"{finalWinner} wins the game! Final Score: {max(p1Points, p2Points)} Beats {min(p1Points, p2Points)}"), delete_after=60)
+        else: 
+            await ctx.send(embed=discord.Embed(title="Zen | Games", description=f"Tie! Final Score: {p1Points, p2Points}"), delete_after=60)
 
 async def setup(client):
     await client.add_cog(Games(client))

--- a/cogs/games.py
+++ b/cogs/games.py
@@ -76,6 +76,7 @@ class Games(commands.Cog, description="Games commands."):
                 ans = await self.client.wait_for('message', check=checkAnswer, timeout = 60)
             except asyncio.TimeoutError:
                 await ctx.send(embed=timeOutEmbed, delete_after=60)
+                return
             if ans.content.lower() in ["y", "yes",]:
                 await ctx.send(embed=discord.Embed(title="Zen | Games", description =f"{ans.author.name} has accepted the challenge!"), delete_after=60)
             else:
@@ -109,6 +110,7 @@ class Games(commands.Cog, description="Games commands."):
                     p2Input = await self.client.wait_for("message", check=checkP2Move, timeout = 60)
                 except asyncio.TimeoutError:
                     await ctx.send(embed=timeOutEmbed, delete_after=60)
+                    return
                 p2Move = playerMoves[p2Input.content.lower()]
             
             winner = checkWinner(p1Move, p2Move)


### PR DESCRIPTION
Hello,

I've finished working on the first version of our Rock-Paper-Scissors game. For a brief overview, the generated embeds are set to delete after 1 minute, the game will conclude by reaching the required points or by absence of required input by the user(s). The user will match with our bot by default if there are no mention of another user in the command. Choice prompts as well as round results are sent privately to the users to avoid the inconvenience of having to switch between the server channel and private message channel, but the overall game result will be displayed in the server channel in which the command was used.  

Here are some examples of how the embeds look like:

challenging another user: 
![image](https://user-images.githubusercontent.com/109928703/210920016-b1669064-1fe7-4b69-8c73-b8da7482e5fc.png)

choice prompt: 
![image](https://user-images.githubusercontent.com/109928703/210920041-54bfb26a-3c87-479b-9b3e-4f41af9d50c8.png)

round result: 
![image](https://user-images.githubusercontent.com/109928703/210920242-28d25dc3-47ca-499d-bc51-3b5d883cb409.png)

final standings: 
![image](https://user-images.githubusercontent.com/109928703/210922735-dc299c05-58ae-4868-b985-25ad25363978.png)

Let me know if you have any recommendations or points that need clarification on.  Here are some possible features for the games that we could expand on:
- ELO system 
- Choosing longer or shorter duration versions of the games
- Coupling the game features with the economy module to gain/lose income

Feel free to add on any thoughts/ideas. Thanks!

